### PR TITLE
Add 'ignore empty' option for trailing spaces and respect ignores.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,15 @@ Test for the maximum amount of newlines between code blocks. Default value is
 
 ### trailingspaces option
 
-Tests for useless whitespaces (trailing whitespaces) at each lineending of all
+Tests for useless whitespaces (trailing whitespaces) at each line ending of all
 files. Default value is `false`.
 
 ```javascript
 	trailingspaces: true
 ```
+
+If you want to exclude lines which only contain whitespace from this check, set 
+`trailingspaces: 'ignore empty'`.
 
 ### indentation options
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -346,9 +346,9 @@ Validator.prototype._validateNewlinesEOF = function() {
  * @private
  */
 Validator.prototype._validateTrailingspaces = function(line, index) {
-	if (this._settings.trailingspaces && typeof line === 'string') {
-		var matchSpaces = line.match(/\s*$/);
-		if (matchSpaces.length > 0 && matchSpaces[0].length > 0) {
+	if (this._settings.trailingspaces && !this._ignoredLines[index] && typeof line === 'string') {
+		var reg = this._settings.trailingspaces === 'ignore empty' ? /\S\s+$/ : /\s+$/;
+		if (reg.test(line)) {
 			this._invalidate(index + 1, MESSAGES.TRAILINGSPACES);
 		}
 	}


### PR DESCRIPTION
Many times, if there is an empty line between two lines of code, that empty line will actually be indented to the block-level of the code it's sandwiched between. I don't consider this bad, or a code-smell, in any way, but the current trailing spaces option complains (making the option unusable).

This PR makes two changes:
- Instead of just true/false, `trailingspaces` can be set to `'ignore empty'` in order to ignore lines which _only_ contain whitespace.
- The trailing spaces now respects the `ignores` option. It doesn't make sense to me why the indentation check respects the ignores, but the trailing spaces check does not. This was also a problem for me.
