### PR TITLE
Make .editorconfig path relative so editorconfig module can find it

### DIFF
--- a/tests/core/editorconfig.js
+++ b/tests/core/editorconfig.js
@@ -13,7 +13,7 @@ exports.tests = {
 			spaces: 2,
 			newline: false,
 			ignores: ['js-comments'],
-			editorconfig: __dirname + '/../../.editorconfig'
+			editorconfig: '.editorconfig'
 		};
 
 		// fake loading:


### PR DESCRIPTION
Before this change, tests/core/editorconfig.js was failing, because
the editorconfig module was concatenating the folder path with the
absolute .editorconfig path, causing an invalid path and test failure.

This change makes the .editorconfig "path" relative, so the editorconfig
plugin simply traverses up the directory tree until it finds it in
the root of the project.
