### PR TITLE
Handle files with Byte Order Marks (BOM)

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -13,9 +13,9 @@ var
 	// Regular Expressions:
 	eol = '\\r?\\n',
 	eolRegExp = new RegExp(eol),
-	tabsRegExp = /^\t*(?!\s).*$/, // leading tabs without leading spaces
+	tabsRegExp = /^\t*(?! |\t).*$/, // leading tabs without leading spaces
 	tabsLeadingRegExp = /^(\t*).*$/, // leading tabs
-	spacesRegExp = /^ *(?!\s).*$/, // leading spaces without leading tabs
+	spacesRegExp = /^ *(?!\t).*$/, // leading spaces without leading tabs
 	spacesLeadingRegExp = /^( *).*$/ // leading spaces
 ;
 

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -13,9 +13,11 @@ var
 	// Regular Expressions:
 	eol = '\\r?\\n',
 	eolRegExp = new RegExp(eol),
-	tabsRegExp = /^\t*(?! |\t).*$/, // leading tabs without leading spaces
+	tabsRegExp = /^\t*(?!\s).*$/, // leading tabs without leading spaces
+	tabsRegExpForBOM = /^\t*(?! |\t).*$/, // leading tabs without leading spaces (allows BOM)
 	tabsLeadingRegExp = /^(\t*).*$/, // leading tabs
-	spacesRegExp = /^ *(?!\t).*$/, // leading spaces without leading tabs
+	spacesRegExp = /^ *(?!\s).*$/, // leading spaces without leading tabs
+	spacesRegExpForBOM = /^ *(?!\t).*$/, // leading spaces without leading tabs (allows BOM)
 	spacesLeadingRegExp = /^( *).*$/ // leading spaces
 ;
 
@@ -408,7 +410,8 @@ Validator.prototype._validateIndentation = function(line, index) {
 
 		switch (this._settings.indentation) {
 			case 'tabs':
-				if (!tabsRegExp.test(line)) {
+				var tabsRegExpFinal = (this._settings.allowsBOM ? tabsRegExpForBOM : tabsRegExp);
+				if (!tabsRegExpFinal.test(line)) {
 					// indentation failed...
 					return this._report(MESSAGES.INDENTATION_TABS, index + 1);
 				}
@@ -417,7 +420,8 @@ Validator.prototype._validateIndentation = function(line, index) {
 				break;
 
 			case 'spaces':
-				if (!spacesRegExp.test(line)) {
+				var spacesRegExpFinal = (this._settings.allowsBOM ? spacesRegExpForBOM : spacesRegExp);
+				if (!spacesRegExpFinal.test(line)) {
 					// Indentation failed...
 					this._report(MESSAGES.INDENTATION_SPACES, index + 1);
 				} else {

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -9,5 +9,6 @@ module.exports = {
 	trailingspacesToIgnores: false, // ignore trailingspaces in ignored lines
 	trailingspacesSkipBlanks: false, // skip trailingspaces in blank lines
 	ignores: false, // pattern or string for lines to ignore
-	editorconfig: false
+	editorconfig: false,
+	allowsBOM: true
 };

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -10,5 +10,5 @@ module.exports = {
 	trailingspacesSkipBlanks: false, // skip trailingspaces in blank lines
 	ignores: false, // pattern or string for lines to ignore
 	editorconfig: false,
-	allowsBOM: true
+	allowsBOM: false
 };

--- a/tests/indentation/fixures/spaces-bom-valid.js
+++ b/tests/indentation/fixures/spaces-bom-valid.js
@@ -1,0 +1,8 @@
+﻿(function() {
+    var foo = 'bar';
+    var index = 0;
+    while (index < foo.length) {
+        console.log(foo.charAt(index));
+        index++;
+    }
+});

--- a/tests/indentation/fixures/tabs-bom-valid.js
+++ b/tests/indentation/fixures/tabs-bom-valid.js
@@ -1,0 +1,8 @@
+﻿(function() {
+	var foo = 'bar';
+	var index = 0;
+	while (index < foo.length) {
+		console.log(foo.charAt(index));
+		index++;
+	}
+});

--- a/tests/indentation/spaces.js
+++ b/tests/indentation/spaces.js
@@ -108,5 +108,23 @@ exports.tests = {
 
 		test.deepEqual({}, report);
 		test.done();
+	},
+
+	'should report an error when file with BOM is not allowed': function(test) {
+		file = __dirname + '/fixures/spaces-bom-valid.js';
+		validator = new Validator({
+			indentation: 'spaces',
+			allowsBOM: false
+		});
+		validator.validate(file);
+		report = validator.getInvalidFiles();
+
+		expected = {};
+		expected[file] = {
+			'1': [merge({}, Messages.INDENTATION_SPACES, {line: 1})]
+		};
+
+		test.deepEqual(expected, report);
+		test.done();
 	}
 };

--- a/tests/indentation/spaces.js
+++ b/tests/indentation/spaces.js
@@ -96,5 +96,17 @@ exports.tests = {
 
 		test.deepEqual({}, report);
 		test.done();
+	},
+
+	'should have no reports when file with BOM is valid': function(test) {
+		file = __dirname + '/fixures/spaces-bom-valid.js';
+		validator = new Validator({
+			indentation: 'spaces'
+		});
+		validator.validate(file);
+		report = validator.getInvalidFiles();
+
+		test.deepEqual({}, report);
+		test.done();
 	}
 };

--- a/tests/indentation/spaces.js
+++ b/tests/indentation/spaces.js
@@ -98,10 +98,11 @@ exports.tests = {
 		test.done();
 	},
 
-	'should have no reports when file with BOM is valid': function(test) {
+	'should have no reports when file with BOM is valid and BOM is allowed': function(test) {
 		file = __dirname + '/fixures/spaces-bom-valid.js';
 		validator = new Validator({
-			indentation: 'spaces'
+			indentation: 'spaces',
+			allowsBOM: true
 		});
 		validator.validate(file);
 		report = validator.getInvalidFiles();

--- a/tests/indentation/tabs.js
+++ b/tests/indentation/tabs.js
@@ -42,5 +42,23 @@ exports.tests = {
 
 		test.deepEqual({}, report);
 		test.done();
+	},
+
+	'should report an error when file with BOM is not allowed': function(test) {
+		file = __dirname + '/fixures/tabs-bom-valid.js';
+		validator = new Validator({
+			indentation: 'tabs',
+			allowsBOM: false
+		});
+		validator.validate(file);
+		report = validator.getInvalidFiles();
+
+		expected = {};
+		expected[file] = {
+			'1': [merge({}, Messages.INDENTATION_TABS, {line: 1})]
+		};
+
+		test.deepEqual(expected, report);
+		test.done();
 	}
 };

--- a/tests/indentation/tabs.js
+++ b/tests/indentation/tabs.js
@@ -32,5 +32,15 @@ exports.tests = {
 
 		test.deepEqual({}, report);
 		test.done();
+	},
+
+	'should have no reports when file with BOM is valid': function(test) {
+		file = __dirname + '/fixures/tabs-bom-valid.js';
+		validator = new Validator({indentation: 'tabs'});
+		validator.validate(file);
+		report = validator.getInvalidFiles();
+
+		test.deepEqual({}, report);
+		test.done();
 	}
 };

--- a/tests/indentation/tabs.js
+++ b/tests/indentation/tabs.js
@@ -34,9 +34,12 @@ exports.tests = {
 		test.done();
 	},
 
-	'should have no reports when file with BOM is valid': function(test) {
+	'should have no reports when file with BOM is valid and BOM is allowed': function(test) {
 		file = __dirname + '/fixures/tabs-bom-valid.js';
-		validator = new Validator({indentation: 'tabs'});
+		validator = new Validator({
+			indentation: 'tabs',
+			allowsBOM: true
+		});
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 


### PR DESCRIPTION
Byte Order Marks (BOM) sometimes occur at the beginning of UTF-8 files.
When they do, they cause lintspaces to give false positives for inconsistent tabs/spaces.

This PR includes tests for files that contain a BOM, and should be considered valid.