### PR TITLE
Update editorconfig, fix npm installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "merge": "1.1.2",
-    "editorconfig": "0.11.4"
+    "editorconfig": "0.12.2"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
The current version of lintspaces isn't installable for me using npm 2.8.3. It looks like the problem is in editorconfig, and updating that to the latest version fixes it for me.

(Financial-Times/origami-build-tools#245)