### PR TITLE
update editorconfig dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "merge": "1.1.2",
-    "editorconfig": "0.11.4"
+    "editorconfig": "0.12.2"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
To avoid this error:
```
npm ERR! Linux 3.18.11-tinycore64
npm ERR! argv "node" "/usr/local/bin/npm" "install" "lintspaces"
npm ERR! node v0.10.38
npm ERR! npm  v2.8.4
npm ERR! path /home/slack-for-linux/node_modules/lintspaces/node_modules/editorconfig/bin\editorconfig
npm ERR! code ENOENT
```