### PR TITLE
Consistent actual/expected in tests

### DIFF
--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -39,7 +39,7 @@ exports.tests = {
 			validator.validate(file);
 		});
 
-		test.deepEqual({}, validator.getInvalidFiles());
+		test.deepEqual(validator.getInvalidFiles(), {});
 		test.done();
 	},
 

--- a/tests/indentation/spaces.js
+++ b/tests/indentation/spaces.js
@@ -94,7 +94,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	},
 
@@ -107,7 +107,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	},
 
@@ -125,7 +125,7 @@ exports.tests = {
 			'1': [merge({}, Messages.INDENTATION_SPACES, {line: 1})]
 		};
 
-		test.deepEqual(expected, report);
+		test.deepEqual(report, expected);
 		test.done();
 	}
 };

--- a/tests/indentation/tabs.js
+++ b/tests/indentation/tabs.js
@@ -30,7 +30,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	},
 
@@ -43,7 +43,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	},
 
@@ -61,7 +61,7 @@ exports.tests = {
 			'1': [merge({}, Messages.INDENTATION_TABS, {line: 1})]
 		};
 
-		test.deepEqual(expected, report);
+		test.deepEqual(report, expected);
 		test.done();
 	}
 };

--- a/tests/newlines/blocks.js
+++ b/tests/newlines/blocks.js
@@ -50,7 +50,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	},
 

--- a/tests/newlines/eof.js
+++ b/tests/newlines/eof.js
@@ -43,7 +43,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	}
 };

--- a/tests/trailingspaces/trailingspaces.js
+++ b/tests/trailingspaces/trailingspaces.js
@@ -31,7 +31,7 @@ exports.tests = {
 		validator.validate(file);
 		report = validator.getInvalidFiles();
 
-		test.deepEqual({}, report);
+		test.deepEqual(report, {});
 		test.done();
 	},
 


### PR DESCRIPTION
I was looking into test failures on Windows (https://github.com/schorfES/node-lintspaces/issues/17) and I noticed that some test failures have the "expected" and "actual" values flipped. Did a quick search through the tests and found a few more, so I decided to do a separate PR for this. I'm still tracking down the source of the Windows problems (guessing it boils down to `\n` vs `\r\n`), but I'll send another PR when I get that figured out.