### PR TITLE
Make tests pass on Windows

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -312,7 +312,7 @@ Validator.prototype._validateNewlineMaximum = function() {
 							.replace('{b}', self._settings.newlineMaximum);
 
 						data = {message: message};
-						data = merge(MESSAGES.NEWLINE_MAXIMUM, data);
+						data = merge({}, MESSAGES.NEWLINE_MAXIMUM, data);
 						line = atLine + 1;
 						payload = {
 							amount: amount,

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -269,18 +269,16 @@ Validator.prototype._validateNewlineMaximum = function() {
 			var
 				self = this,
 
-				// To grep all all blocks at the begin of a file
+				// To grep all blocks at the begining of a file
 				// which have at least 1 more new line than the defined
-				// criteria the expression for one or more newlines is
-				// appended:
-				newlinesAtBeginn = '^[' + eol + ']{' + this._settings.newlineMaximum + '}' + eol + '+',
+				// criteria, match "newlineMaximum + 1" (or more) instances of eol:
+				newlinesAtBeginn = '^(?:' + eol + '){' + (this._settings.newlineMaximum + 1) + ',}',
 
 				// Each block inside a file has an extra leading newline
-				// from the previous line above (+1). To grep all all blocks
-				// which have at least 1 more new line than the defined
-				// criteria the expression for one or more newlines is
-				// appended:
-				newlinesInFile = '[' + eol + ']{' + (this._settings.newlineMaximum + 1) + '}' + eol + '+',
+				// from the previous line above. To grep all blocks
+				// which have at least 1 more new line than the defined criteria,
+				// match "newlineMaximum + 2" (or more) instances of eol:
+				newlinesInFile = '(?:' + eol + '){' + (this._settings.newlineMaximum + 2) + ',}',
 
 				// Define function which is used as fake replace cycle to
 				// validate matches:


### PR DESCRIPTION
This fixes https://github.com/schorfES/node-lintspaces/issues/17

The issue with the validator is that it was trying to match *either* `\r` or `?` or `\n` with `[\r?\n]`. Switching it to use a non-capturing group `(?:\r?\n)` makes it correctly match newlines, but it also makes the regex non-greedy, so the `\r?\n+` at the end was only capturing one newline. By switching to the simpler `{n,}` style syntax for "n or more", the regex is simplified and fixed at the same time :)