### PR TITLE
Add validation against multiple indentation

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -71,6 +71,13 @@ Validator.prototype.validate = function(path) {
 			self._validateTrailingspaces(line, index);
 		});
 
+		// Only run multiple indentation validation if no other errors found
+		// Otherwise interactions between complicated mixed indentation
+		// and multiple detection algorithm are too copmplex.
+		if (Object.keys(this._invalid).length === 0) {
+			this._validateMultipleIndentation();
+		}
+
 		// Validation is done:
 		this._done();
 	} else {
@@ -381,6 +388,55 @@ Validator.prototype._validateNewlinesEOF = function() {
 		// check line before last line:
 		if (this._lines[index - 1].length === 0) {
 			this._report(MESSAGES.NEWLINE_AMOUNT, index + 1);
+		}
+	}
+};
+
+/**
+ * Check whether some lines have multiple indentation (4 spaces instead of 2)
+ * @private
+ */
+Validator.prototype._validateMultipleIndentation = function() {
+	var detectIndentSizes, indentSizes, settingCount, allIndentsAvailable;
+
+	detectIndentSizes = function(regex, data) {
+		var result, fill;
+		result = {};
+		fill = function(match) {
+			if (!match) {
+				return;
+			}
+			result[match[1].length] = true;
+		};
+		data.split('\n').forEach(function(line) {
+			fill(regex.exec(line));
+		});
+		return result;
+	};
+
+	allIndentsAvailable = function(sizes, count) {
+		var i = Math.max.apply(null, Object.keys(sizes));
+		while (i > 0) {
+			if (!sizes[i]) {
+				return false;
+			}
+			i -= count;
+		}
+		return true;
+	};
+
+	if (typeof this._settings.indentation === 'string') {
+		if (this._settings.indentation === 'spaces') {
+			indentSizes = detectIndentSizes(spacesLeadingRegExp, this._data);
+			if (!this._settings.spaces) {
+				return;
+			}
+		} else {
+			indentSizes = detectIndentSizes(tabsLeadingRegExp, this._data);
+		}
+		settingCount = this._settings.spaces || 1;
+		if (!allIndentsAvailable(indentSizes, settingCount)) {
+			this._report(MESSAGES.INDENTATION_MULTIPLE, 1);
 		}
 	}
 };

--- a/lib/constants/messages.js
+++ b/lib/constants/messages.js
@@ -13,6 +13,11 @@ module.exports = {
 	//  * type (warning or hint)
 	//  * message (the message)
 	// -------------------------------------------------------------------------
+	INDENTATION_MULTIPLE: {
+		code: 'INDENTATION_MULTIPLE',
+		type: types.WARNING,
+		message: 'Some indentation levels seem to be skipped'
+	},
 	INDENTATION_TABS: {
 		code: 'INDENTATION_TABS',
 		type: types.WARNING,

--- a/tests/indentation/fixures/spaces-invalid-double.js
+++ b/tests/indentation/fixures/spaces-invalid-double.js
@@ -1,0 +1,8 @@
+(function() {
+    var foo = 'bar';
+    var index = 0;
+    while (index < foo.length) {
+        console.log(foo.charAt(index));
+        index++;
+    }
+});

--- a/tests/indentation/spaces.js
+++ b/tests/indentation/spaces.js
@@ -127,5 +127,23 @@ exports.tests = {
 
 		test.deepEqual(report, expected);
 		test.done();
-	}
+	},
+	
+	'should report errors when indentation is double': function(test) {
+		file = __dirname + '/fixures/spaces-invalid-double.js';
+		validator = new Validator({
+			indentation: 'spaces',
+			spaces: 2
+		});
+		validator.validate(file);
+		report = validator.getInvalidFiles();
+		
+		expected = {};
+		expected[file] = {
+			'1': [merge({}, Messages.INDENTATION_MULTIPLE, {line: 1})]
+		};
+
+		test.deepEqual(report, expected);
+		test.done();
+	},
 };


### PR DESCRIPTION
If a file is indented using 4 spaces instead of 2, this will warn the user instead of assuming that there are two levels of indentation.

This is breaking BC! If you want to hide this algorithm behind an option, I will add that.

I am very open to harsh criticism about the code style.
