### PR TITLE
Use the version number for npm instead of github

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "merge": "1.1.2",
-    "editorconfig": "editorconfig/editorconfig-core-js#50e0dba"
+    "editorconfig": "0.11.4"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Using the github tag can break build processes because of github limits.