### PR TITLE
Fixes #29. Allows indentationGuess to skip blank lines in logic.

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -546,17 +546,18 @@ Validator.prototype._guessIndentation = function(line, index) {
 			matchPrevious = 0,
 			diff,
 			message,
-			data
+			data,
+			n = 1
 		;
 
 		// Get amount of whitespaces at the beginnig of a line for the
 		// current line and the previous line:
 		match = match.length > 1 ? match[1].length : 0;
-		if (index > 0) {
-			matchPrevious = this._lines[index - 1].match(regExp);
+		while (index >= n && matchPrevious === 0) {
+			matchPrevious = this._lines[index - n].match(regExp);
 			matchPrevious = matchPrevious.length > 1 ? matchPrevious[1].length : 0;
+			n++;
 		}
-
 		// Calculate the indentation for both lines:
 		indentation = match;
 		indentationPrevious = matchPrevious;

--- a/tests/indentation/fixures/guess-newline.js
+++ b/tests/indentation/fixures/guess-newline.js
@@ -1,0 +1,10 @@
+(function() {
+	var foo = 'bar';
+	var index = 0;
+	while (index < foo.length) {
+
+
+			console.log(foo.charAt(index));
+		index++;
+	}
+});

--- a/tests/indentation/guess.js
+++ b/tests/indentation/guess.js
@@ -9,6 +9,33 @@ var
 ;
 
 exports.tests = {
+	'should guess incorrect indentation disregarding newlines': function(test) {
+		file = __dirname + '/fixures/guess-newline.js';
+		validator = new Validator({
+			indentation: 'tabs',
+			indentationGuess: true
+		});
+		validator.validate(file);
+		report = validator.getInvalidFiles();
+		expected = {};
+		expected[file] = {
+			'7': [merge({}, Messages.INDENTATION_GUESS, {
+				message: Messages
+					.INDENTATION_GUESS
+					.message
+					.replace('{a}', 2)
+					.replace('{b}', 3),
+				line: 7,
+				payload: {
+					indentation: 3,
+					expected: 2
+				}
+			})],
+		};
+		test.deepEqual(report, expected);
+		test.done();
+	},
+
 	'should guess incorrect indentation using tabs': function(test) {
 		file = __dirname + '/fixures/guess-tabs.js';
 		validator = new Validator({


### PR DESCRIPTION
Here is a PR to address issue #29. It is working for my expectations. I don't think it's a perfect PR, but it accomplishes what I need it to, which is to allow the indentation guess functionality to skip over completely blank lines in its logic. I'm happy to alter this if needed.