### PR TITLE
Fix ignored singleline file in "newline at end of file" option

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -426,21 +426,23 @@ Validator.prototype._validateNewlineMaximum = function() {
  * @private
  */
 Validator.prototype._validateNewlinesEOF = function() {
-	if (this._settings.newline && this._lines.length > 1) {
-		var
-			index = this._lines.length - 1
-		;
+	if (!this._settings.newline) {
+		return;
+	}
+
+	var
+		index = this._lines.length - 1
+	;
 
 
-		// check last line:
-		if (this._lines[index].length > 0) {
-			this._report(MESSAGES.NEWLINE, index + 1);
-		}
+	// check last line:
+	if (this._lines[index].length > 0) {
+		this._report(MESSAGES.NEWLINE, index + 1);
+	}
 
-		// check line before last line:
-		if (this._lines[index - 1].length === 0) {
-			this._report(MESSAGES.NEWLINE_AMOUNT, index + 1);
-		}
+	// check line before last line:
+	if (index - 1 > 0 && this._lines[index - 1].length === 0) {
+		this._report(MESSAGES.NEWLINE_AMOUNT, index + 1);
 	}
 };
 

--- a/lib/Validator.test.js
+++ b/lib/Validator.test.js
@@ -826,6 +826,18 @@ describe('The validator', () => {
 				});
 			});
 
+			it('should report missing on singleline file', () => {
+				const file = __fromFixtures('newlines.endoffile.singleline.fixture');
+				const validator = new Validator({newline: true});
+				validator.validate(file);
+
+				expect(validator.getInvalidFiles()).toEqual({
+					[file]: {
+						'1': [extend({}, Messages.NEWLINE, {line: 1})],
+					},
+				});
+			});
+
 			it('should report too much', () => {
 				const file = __fromFixtures('newlines.endoffile.invalid.much.fixture');
 				const validator = new Validator({newline: true});

--- a/lib/__fixtures__/newlines.endoffile.singleline.fixture
+++ b/lib/__fixtures__/newlines.endoffile.singleline.fixture
@@ -1,0 +1,1 @@
+module.exports = function() { console.log('foobar'); };


### PR DESCRIPTION
This fixes the bug that files with a single line were ignored from the [newline at end of file option](https://github.com/schorfES/node-lintspaces#newline-at-end-of-file-option) as reported by @the-t-in-rtf in #70.