### PR TITLE
Handle unset and invalid values from editor config #47

### DIFF
--- a/src/Validator.test.js
+++ b/src/Validator.test.js
@@ -159,7 +159,7 @@ describe('The validator', () => {
 				expect(validator._settings.trailingspaces).toBeFalsy();
 				expect(validator._settings.newline).toBeFalsy();
 				expect(validator._settings.indentation).toBe('tabs');
-				expect(validator._settings.spaces).toBe('tab');
+				expect(validator._settings.spaces).toBe(false);
 				expect(validator._settings.endOfLine).toBe('lf');
 
 				// Unchanged:
@@ -210,9 +210,59 @@ describe('The validator', () => {
 
 				// test for expected properties by editorconfig:
 				expect(validator._settings.indentation).toBe('tabs');
-				expect(validator._settings.spaces).toBe('tab');
+				expect(validator._settings.spaces).toBe(false);
 				expect(validator._settings.trailingspaces).toBeTruthy();
 				expect(validator._settings.newline).toBeTruthy();
+			});
+
+			it('should parse "unset" value as false', () => {
+				// fake loading:
+				const validator = new Validator({
+					editorconfig: __fromFixtures('.editorconfig.unset'),
+
+					trailingspaces: true,
+					newline: true,
+
+					indentation: 'spaces',
+					spaces: 2,
+					endOfLine: true,
+				});
+
+				// Load editorconfig with extension where options are disabled:
+				validator._path = __fromFixtures('core.fixture');
+				validator._loadSettings();
+				expect(validator._settings).toEqual(expect.objectContaining({
+					trailingspaces: false,
+					newline: false,
+					indentation: false,
+					spaces: false,
+					endOfLine: false,
+				}))
+			});
+
+			it('should parse invalid value as false', () => {
+				// fake loading:
+				const validator = new Validator({
+					editorconfig: __fromFixtures('.editorconfig.invalid'),
+
+					trailingspaces: true,
+					newline: true,
+
+					indentation: 'spaces',
+					spaces: 2,
+					endOfLine: true,
+				});
+
+				// Load editorconfig with extension where options are disabled:
+				validator._path = __fromFixtures('core.fixture');
+				validator._loadSettings();
+				expect(validator._settings).toEqual(expect.objectContaining({
+					trailingspaces: false,
+					newline: false,
+					indentation: false,
+					spaces: false,
+					endOfLine: false,
+				}))
 			});
 
 			it('should throw if is not a file', () => {

--- a/src/__fixtures__/.editorconfig.invalid
+++ b/src/__fixtures__/.editorconfig.invalid
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = cf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.fixture]
+indent_style = foo
+indent_size = bar
+end_of_line = baz
+insert_final_newline = qux
+trim_trailing_whitespace = quux

--- a/src/__fixtures__/.editorconfig.unset
+++ b/src/__fixtures__/.editorconfig.unset
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = cf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.fixture]
+indent_style = unset
+indent_size = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset

--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -12,5 +12,5 @@ module.exports = {
 	editorconfig: false, // path to editor-config file
 	rcconfig: false, // path to rc-config file
 	allowsBOM: false,
-	end_of_line: false, // 'LF' or 'CRLF' or 'CR' or false to disable checking
+	endOfLine: false, // 'LF' or 'CRLF' or 'CR' or false to disable checking
 };

--- a/src/constants/editorconfig-mappings.js
+++ b/src/constants/editorconfig-mappings.js
@@ -1,8 +1,0 @@
-module.exports = {
-	charset: 'encoding',
-	insert_final_newline: 'newline',
-	indent_style: 'indentation',
-	indent_size: 'spaces',
-	trim_trailing_whitespace: 'trailingspaces',
-	end_of_line: 'endOfLine',
-};

--- a/src/constants/editorconfigMappings.js
+++ b/src/constants/editorconfigMappings.js
@@ -1,0 +1,32 @@
+module.exports = {
+	charset: {
+		name: 'encoding',
+		types: ['string'],
+		regexp: /^.*$/,
+	},
+	insert_final_newline: {
+		name: 'newline',
+		types: ['boolean'],
+		regexp: false,
+	},
+	indent_style: {
+		name: 'indentation',
+		types: ['string'],
+		regexp: /^tab|space$/i,
+	},
+	indent_size: {
+		name: 'spaces',
+		types: ['number'],
+		regexp: false,
+	},
+	trim_trailing_whitespace: {
+		name: 'trailingspaces',
+		types: ['boolean'],
+		regexp: false,
+	},
+	end_of_line: {
+		name: 'endOfLine',
+		types: ['string'],
+		regexp: /^lf|crlf|cr$/i,
+	},
+};


### PR DESCRIPTION
This PR addresses issue #47 by implementing support for handling `'unset'` or invalid values from EditorConfig. Specifically, it ensures that these values disable the corresponding settings, maintaining consistent behavior across configurations.