### PR TITLE
Handle multiline spaced comments

### DIFF
--- a/src/Validator.js
+++ b/src/Validator.js
@@ -563,12 +563,6 @@ class Validator {
 				? REGEXP_INDENTATION_SPACES_WITH_BOM
 				: REGEXP_INDENTATION_SPACES;
 
-			let spacesExpected;
-			let indent;
-			let message;
-			let data;
-			let payload;
-
 			switch (this._settings.indentation) {
 				case 'tabs':
 					if (!tabsRegExpFinal.test(line)) {
@@ -586,7 +580,8 @@ class Validator {
 					} else {
 						// Indentation correct, is amount of spaces correct?
 						if (typeof this._settings.spaces === 'number') {
-							indent = line.match(REGEXP_LEADING_SPACES)[1].length;
+							const indent = line.match(REGEXP_LEADING_SPACES)[1].length;
+
 							if (
 								indent % this._settings.spaces !== 0
 								&& (
@@ -595,19 +590,18 @@ class Validator {
 								)
 							) {
 								// Indentation incorrect, create message and report:
-								spacesExpected = Math.round(indent / this._settings.spaces) * this._settings.spaces;
-								message = MESSAGES.INDENTATION_SPACES_AMOUNT.message
+								const spacesExpected = Math.round(indent / this._settings.spaces) * this._settings.spaces;
+								const message = MESSAGES.INDENTATION_SPACES_AMOUNT.message
 									.replace('{a}', spacesExpected)
 									.replace('{b}', indent);
 
-								data = {message: message};
+								let data = {message};
 								data = extend({}, MESSAGES.INDENTATION_SPACES_AMOUNT, data);
-								payload = {
-									expected: spacesExpected,
-									indent: indent,
-								};
 
-								this._report(data, index + 1, payload);
+								this._report(data, index + 1, {
+									expected: spacesExpected,
+									indent,
+								});
 							}
 						}
 					}

--- a/src/Validator.test.js
+++ b/src/Validator.test.js
@@ -692,6 +692,9 @@ describe('The validator', () => {
 							'5': [extend({}, Messages.INDENTATION_SPACES, {line: 5})],
 							'6': [extend({}, Messages.INDENTATION_SPACES, {line: 6})],
 							'7': [extend({}, Messages.INDENTATION_SPACES, {line: 7})],
+							'8': [extend({}, Messages.INDENTATION_SPACES, {line: 8})],
+							'9': [extend({}, Messages.INDENTATION_SPACES, {line: 9})],
+							'10': [extend({}, Messages.INDENTATION_SPACES, {line: 10})],
 						},
 					});
 				});
@@ -736,13 +739,13 @@ describe('The validator', () => {
 									indent: 5,
 								},
 							})],
-							'5': [extend({}, Messages.INDENTATION_SPACES_AMOUNT, {
+							'8': [extend({}, Messages.INDENTATION_SPACES_AMOUNT, {
 								message: Messages
 									.INDENTATION_SPACES_AMOUNT
 									.message
 									.replace('{a}', 12)
 									.replace('{b}', 10),
-								line: 5,
+								line: 8,
 								payload: {
 									expected: 12,
 									indent: 10,

--- a/src/__fixtures__/indentation.spaces.fixture
+++ b/src/__fixtures__/indentation.spaces.fixture
@@ -2,6 +2,9 @@
     var foo = 'bar';
     var index = 0;
     while (index < foo.length) {
+        /**
+         * This line and the next should not fail
+         */
         console.log(foo.charAt(index));
         index++;
     }

--- a/src/__fixtures__/indentation.spaces.invalid.fixture
+++ b/src/__fixtures__/indentation.spaces.invalid.fixture
@@ -2,6 +2,9 @@
     var foo = 'bar';
      var index = 0;
     while (index < foo.length) {
+        /**
+         * Not incorrect
+         */
           console.log(foo.charAt(index));
         index++;
     }

--- a/src/__fixtures__/indentation.tabs.fixture
+++ b/src/__fixtures__/indentation.tabs.fixture
@@ -2,6 +2,9 @@
 	var foo = 'bar';
 	var index = 0;
 	while (index < foo.length) {
+		/**
+		 * This line and the next should not fail
+		 */
 		console.log(foo.charAt(index));
 		index++;
 	}


### PR DESCRIPTION
This is my attempt to fix #297 

To easily check the difference between old and new check, you can go to the code on line 107 and put in comment the `insideComment = true`  flag so it never adapt to comment section. In such case it will fail like the old code.

It should handle all sorts of multiline spaced comments:
```js
/**
 * Like this
 */

/**
* Or this
*/

/**
*Even this
*/

/**
 *And finally that
*/
```