### PR TITLE
ci: update matrix to currently supported Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [16, 17, 18, 19, 20, 22]
+        node:
+          - 18
+          - 20
+          - 22
+          - 23
 
     steps:
       - name: Git checkout


### PR DESCRIPTION
Dropped EOL 16, 17, 19, and added 23.
Pushed the array format to list format for easier diff in the future as items are added/removed.