### PR TITLE
ci: enable NPM caching with npm ci installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          cache: 'npm'
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
Added in a previous major release, and recommended in the docs https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data